### PR TITLE
feat: Remove guides from specs menu

### DIFF
--- a/docs-src/docs/guides/_category_.json
+++ b/docs-src/docs/guides/_category_.json
@@ -1,8 +1,0 @@
-{
-  "position": 8,
-  "label": "Guides",
-  "link": {
-    "type": "generated-index",
-    "title": "Guides"
-  }
-}

--- a/docs-src/docs/guides/deploy.md
+++ b/docs-src/docs/guides/deploy.md
@@ -1,3 +1,0 @@
-# Deploy
-
-(coming soon)


### PR DESCRIPTION
# Description

Remove guides from specs menu. Deployment related guides should not be part of the Spec Docs.
